### PR TITLE
Add default "resolvedIf" function for tasks

### DIFF
--- a/src/lib/validate-declarative-schema.js
+++ b/src/lib/validate-declarative-schema.js
@@ -104,7 +104,7 @@ const TaskSchema = joi.array().items(
     contactLabel:
       joi.alternatives().try( joi.string().min(1), joi.function() ).optional()
       .error(taskError('"contactLabel" should either be a non-empty string or function(contact, report)')),
-    resolvedIf: joi.function().required()
+    resolvedIf: joi.function().optional()
       .error(taskError('"resolvedIf" should be of type function(contact, report)')),
     events: joi.alternatives().conditional('events', {
       is: joi.array().length(1),

--- a/src/nools/definition-preparation.js
+++ b/src/nools/definition-preparation.js
@@ -8,6 +8,9 @@ function prepare(definition) {
   var targetContext = {};
   bindAllFunctionsToContext(definition, targetContext);
   targetContext.definition = deepCopy(definition);
+  targetContext.defaultResolvedIf = function (contact, report, event, dueDate, resolvingForm) {
+    return Utils.defaultResolvedIf(contact, report, event, dueDate, resolvingForm || this.definition.actions[0].form);
+  };
 }
 
 function bindAllFunctionsToContext(obj, context) {

--- a/src/nools/definition-preparation.js
+++ b/src/nools/definition-preparation.js
@@ -4,27 +4,16 @@ Definition-preparation.js binds a value for `this` in all the functions within a
 This fascilitates simple data sharing between functions, and allows function logic to reference the definition itself.
 */
 
-function prepare(definition, Utils) {
+function prepare(definition, defaultResolvedIf, Utils) {
   var targetContext = {};
   bindAllFunctionsToContext(definition, targetContext);
   targetContext.definition = deepCopy(definition);
-  targetContext.defaultResolvedIf = function (contact, report, event, dueDate, resolvingForm) {
-    var start = 0;
-    if (report) {//Report based task
-      //Start of the task window or after the report's reported date, whichever comes later
-      start = Math.max(Utils.addDate(dueDate, -event.start).getTime(), report.reported_date + 1);
-    }
-    else {
-      start = Utils.addDate(dueDate, -event.start).getTime();
-    }
-    var end = Utils.addDate(dueDate, event.end + 1).getTime();
-    return Utils.isFormSubmittedInWindow(
-      contact.reports,
-      resolvingForm || this.definition.actions[0].form,
-      start,
-      end
-    );
-  };
+  if (defaultResolvedIf) {
+    targetContext.defaultResolvedIf = function (contact, report, event, dueDate, resolvingForm) {
+      return defaultResolvedIf(contact, report, event, dueDate, resolvingForm || definition.actions[0].form, Utils);
+    };
+
+  }
 }
 
 function bindAllFunctionsToContext(obj, context) {

--- a/src/nools/definition-preparation.js
+++ b/src/nools/definition-preparation.js
@@ -4,12 +4,26 @@ Definition-preparation.js binds a value for `this` in all the functions within a
 This fascilitates simple data sharing between functions, and allows function logic to reference the definition itself.
 */
 
-function prepare(definition) {
+function prepare(definition, Utils) {
   var targetContext = {};
   bindAllFunctionsToContext(definition, targetContext);
   targetContext.definition = deepCopy(definition);
   targetContext.defaultResolvedIf = function (contact, report, event, dueDate, resolvingForm) {
-    return Utils.defaultResolvedIf(contact, report, event, dueDate, resolvingForm || this.definition.actions[0].form);
+    var start = 0;
+    if (report) {//Report based task
+      //Start of the task window or after the report's reported date, whichever comes later
+      start = Math.max(Utils.addDate(dueDate, -event.start).getTime(), report.reported_date + 1);
+    }
+    else {
+      start = Utils.addDate(dueDate, -event.start).getTime();
+    }
+    var end = Utils.addDate(dueDate, event.end + 1).getTime();
+    return Utils.isFormSubmittedInWindow(
+      contact.reports,
+      resolvingForm || this.definition.actions[0].form,
+      start,
+      end
+    );
   };
 }
 

--- a/src/nools/task-emitter.js
+++ b/src/nools/task-emitter.js
@@ -6,7 +6,7 @@ function taskEmitter(taskDefinitions, c, Utils, Task, emit) {
   var taskDefinition, r;
   for (var idx1 = 0; idx1 < taskDefinitions.length; ++idx1) {
     taskDefinition = taskDefinitions[idx1];
-    prepareDefinition(taskDefinition, Utils);
+    prepareDefinition(taskDefinition, defaultResolvedIf, Utils);
 
     switch (taskDefinition.appliesTo) {
       case 'reports':
@@ -127,21 +127,7 @@ function emitTasks(taskDefinition, Utils, Task, emit, c, r) {
         task.resolved = taskDefinition.resolvedIf(c, r, event, dueDate, scheduledTaskIdx);
       }
       else {
-        var start = 0;
-        if (r) {//Report based task
-          //Start of the task window or after the report's reported date, whichever comes later
-          start = Math.max(Utils.addDate(dueDate, -event.start).getTime(), r.reported_date + 1);
-        }
-        else {
-          start = Utils.addDate(dueDate, -event.start).getTime();
-        }
-        var end = Utils.addDate(dueDate, event.end + 1).getTime();
-        task.resolved = Utils.isFormSubmittedInWindow(
-          c.reports,
-          taskDefinition.actions[0].form,
-          start,
-          end
-        );
+        task.resolved = defaultResolvedIf(c, r, event, dueDate, taskDefinition.actions[0].form, Utils);
       }
 
       if (scheduledTaskIdx !== undefined) {
@@ -181,6 +167,24 @@ function emitTasks(taskDefinition, Utils, Task, emit, c, r) {
       content: content,
     };
   }
+}
+
+function defaultResolvedIf (c, r, event, dueDate, resolvingForm, Utils) {
+  var start = 0;
+  if (r) {//Report based task
+    //Start of the task window or after the report's reported date, whichever comes later
+    start = Math.max(Utils.addDate(dueDate, -event.start).getTime(), r.reported_date + 1);
+  }
+  else {
+    start = Utils.addDate(dueDate, -event.start).getTime();
+  }
+  var end = Utils.addDate(dueDate, event.end + 1).getTime();
+  return Utils.isFormSubmittedInWindow(
+    c.reports,
+    resolvingForm,
+    start,
+    end
+  );
 }
 
 module.exports = taskEmitter;

--- a/src/nools/task-emitter.js
+++ b/src/nools/task-emitter.js
@@ -120,9 +120,15 @@ function emitTasks(taskDefinition, Utils, Task, emit, c, r) {
         readyStart: event.start || 0,
         readyEnd: event.end || 0,
         title: taskDefinition.title,
-        resolved: taskDefinition.resolvedIf(c, r, event, dueDate, scheduledTaskIdx),
         actions: taskDefinition.actions.map(initActions),
       };
+
+      if (typeof taskDefinition.resolvedIf === 'function') {
+        task.resolved = taskDefinition.resolvedIf(c, r, event, dueDate, scheduledTaskIdx);
+      }
+      else {
+        task.resolved = Utils.defaultResolvedIf(c, r, event, dueDate, taskDefinition.actions[0].form);
+      }
 
       if (scheduledTaskIdx !== undefined) {
         task._id += '-' + scheduledTaskIdx;

--- a/src/nools/task-emitter.js
+++ b/src/nools/task-emitter.js
@@ -6,7 +6,7 @@ function taskEmitter(taskDefinitions, c, Utils, Task, emit) {
   var taskDefinition, r;
   for (var idx1 = 0; idx1 < taskDefinitions.length; ++idx1) {
     taskDefinition = taskDefinitions[idx1];
-    prepareDefinition(taskDefinition);
+    prepareDefinition(taskDefinition, Utils);
 
     switch (taskDefinition.appliesTo) {
       case 'reports':
@@ -127,7 +127,21 @@ function emitTasks(taskDefinition, Utils, Task, emit, c, r) {
         task.resolved = taskDefinition.resolvedIf(c, r, event, dueDate, scheduledTaskIdx);
       }
       else {
-        task.resolved = Utils.defaultResolvedIf(c, r, event, dueDate, taskDefinition.actions[0].form);
+        var start = 0;
+        if (r) {//Report based task
+          //Start of the task window or after the report's reported date, whichever comes later
+          start = Math.max(Utils.addDate(dueDate, -event.start).getTime(), r.reported_date + 1);
+        }
+        else {
+          start = Utils.addDate(dueDate, -event.start).getTime();
+        }
+        var end = Utils.addDate(dueDate, event.end + 1).getTime();
+        task.resolved = Utils.isFormSubmittedInWindow(
+          c.reports,
+          taskDefinition.actions[0].form,
+          start,
+          end
+        );
       }
 
       if (scheduledTaskIdx !== undefined) {

--- a/test/nools/task-emitter.spec.js
+++ b/test/nools/task-emitter.spec.js
@@ -100,6 +100,25 @@ describe('task-emitter', () => {
         ]);
       });
 
+      it('resolvedIf is not required', () => {
+        // given
+        const config = {
+          c: personWithReports(aReport()),
+          targets: [],
+          tasks: [ aPersonBasedTask() ],
+        };
+        delete config.tasks[0].resolvedIf;
+
+        // when
+        const { emitted } = runNoolsLib(config);
+
+        // then
+        expect(emitted[0]).to.nested.include({
+          'actions[0].content.source_id': 'c-2',
+          resolved: false,
+        });
+      });
+
       it('emitted task for configurable hierarchy contact', () => {
         // given
         const config = {
@@ -287,6 +306,25 @@ describe('task-emitter', () => {
         });
       });
 
+      it('resolvedIf is not required', () => {
+        // given
+        const config = {
+          c: personWithReports(aReport()),
+          targets: [],
+          tasks: [ aReportBasedTask() ],
+        };
+        delete config.tasks[0].resolvedIf;
+
+        // when
+        const { emitted } = runNoolsLib(config);
+
+        // then
+        expect(emitted[0]).to.nested.include({
+          'actions[0].content.source_id': 'r-1',
+          resolved: false,
+        });
+      });
+
       it('should emit once per report', () => {
         // given
         const config = {
@@ -374,6 +412,34 @@ describe('task-emitter', () => {
         const expected = new Date();
         expected.setHours(0, 0, 0, 0);
         expect(emitted[0].date.getTime()).to.eq(expected.getTime());
+      });
+
+      it('given task definition without resolved_date, resolvedIf defaults to Utils.resolvedIf and resolves the task', () => {
+        sinon.useFakeTimers();
+
+        // given
+        const config = {
+          c: personWithReports(aReport()),
+          targets: [],
+          tasks: [aPersonBasedTask()],
+        };
+        delete config.tasks[0].resolvedIf;
+        // when
+        const { emitted } = runNoolsLib(config);
+
+        //then
+        expect(emitted[0].resolved).to.be.false;
+        
+        //given
+        const resolvingReport = aReport();
+        resolvingReport.form = 'example-form';
+
+        //when
+        config.c.reports.push(resolvingReport);
+        const emittedAgain = runNoolsLib(config).emitted;
+
+        //then
+        expect(emittedAgain[0].resolved).to.be.true;
       });
 
       it('dueDate function is invoked with expected data', () => {

--- a/test/nools/task-emitter.spec.js
+++ b/test/nools/task-emitter.spec.js
@@ -383,6 +383,41 @@ describe('task-emitter', () => {
 
       });
 
+      it('this.defaultResolvedIf can be used with specific resolving form', () => {
+        // given
+        const config = {
+          c: personWithReports(aReport()),
+          targets: [],
+          tasks: [aReportBasedTask()],
+        };
+
+        config.tasks[0].resolvedIf = function (contact, report, event, dueDate) {
+          return this.defaultResolvedIf(contact, report, event, dueDate, 'specific-form');
+        };
+
+        // when
+        const { emitted } = runNoolsLib(config);
+
+        // then
+        expect(emitted[0]).to.nested.include({
+          'actions[0].content.source_id': 'r-1',
+          resolved: false,//not resolved
+        });
+
+        //given
+        const resolvingReport = aReport();
+        resolvingReport.form = 'specific-form';
+        resolvingReport.reported_date = TEST_DATE + 1;
+
+        //when
+        config.c.reports.push(resolvingReport);
+        let emittedAgain = runNoolsLib(config).emitted;
+
+        //then
+        expect(emittedAgain[0].resolved).to.be.true;//resolved
+
+      });
+
       it('should emit once per report', () => {
         // given
         const config = {

--- a/test/run-nools-lib.js
+++ b/test/run-nools-lib.js
@@ -33,14 +33,6 @@ const runNoolsLib = ({ c, targets, tasks }) => {
         });
         return result;
       },
-      defaultResolvedIf: function (contact, report, event, dueDate, resolvingForm) {
-        return this.isFormSubmittedInWindow(
-          contact.reports,
-          resolvingForm,
-          report ? Math.max(this.addDate(dueDate, -event.start).getTime(), report.reported_date + 1) : this.addDate(dueDate, -event.start).getTime(),
-          this.addDate(dueDate, event.end + 1).getTime()
-        );
-      }
     },
     Target: function(props) {
       this._id = props._id;

--- a/test/run-nools-lib.js
+++ b/test/run-nools-lib.js
@@ -19,6 +19,28 @@ const runNoolsLib = ({ c, targets, tasks }) => {
       },
       now: () => new Date(TEST_DATE),
       isTimely: function() { return true; },
+      isFormSubmittedInWindow: function(reports, form, start, end, count) {
+        let result = false;
+        reports.forEach(function(report) {
+          if (!result && report.form === form) {
+            if (report.reported_date >= start && report.reported_date <= end) {
+              if (!count ||
+                 (count && report.fields && report.fields.follow_up_count > count)) {
+                result = true;
+              }
+            }
+          }
+        });
+        return result;
+      },
+      defaultResolvedIf: function (contact, report, event, dueDate, resolvingForm) {
+        return this.isFormSubmittedInWindow(
+          contact.reports,
+          resolvingForm,
+          report ? Math.max(this.addDate(dueDate, -event.start).getTime(), report.reported_date + 1) : this.addDate(dueDate, -event.start).getTime(),
+          this.addDate(dueDate, event.end + 1).getTime()
+        );
+      }
     },
     Target: function(props) {
       this._id = props._id;


### PR DESCRIPTION
# Description

Adds a default `resolvedIf` function for tasks.

medic/medic-conf#107

## defaultResolvedIf
- Uses [Utils.isFormSubmittedInWindow](https://github.com/medic/medic-nootils/blob/4339b25201bfbf51eef9179c8b7e0e92734a0d48/src/nootils.js#L57) to check if the resolving form has been submitted within a time period:
    - For contact-based tasks, the period is the same as the task window period
    - For report based tasks, the period is determined as follows:
        - start: start of the task window or 1 millisecond after reported date of the source report, whichever comes later
        - end: end of the task window
    - The resolving form is the task's first action form


## Usage
Options:
A. Skip `resolvedIf` section in the task definition, `defaultResolvedIf` will be used automatically
B. Using `this.defaultResolvedIf`:
1. Without specifying the parameters:
    ```
    resolvedIf: this.defaultResolvedIf,
    ```

2. Specifying parameters and optionally add other conditions:
    ```
    resolvedIf: function (contact, report, event, dueDate) {
      return this.defaultResolvedIf(contact, report, event, dueDate) && ...
    },
    ```
3. Specifying the resolving form type if it is different from the default (form type specified in the first action of the task):
    ```
    resolvedIf: function (contact, report, event, dueDate) {
      return this.defaultResolvedIf(contact, report, event, dueDate, 'delivery');
    },
    ```
# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
